### PR TITLE
Add Streamlit Q&A app with vector store

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# MangaGPT
+
+This project downloads manga chapter pages, builds a vector store using
+OpenAI embeddings and exposes a simple question–answer interface through
+Streamlit.
+
+## Setup
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Provide your OpenAI API key:
+
+   ```bash
+   export OPENAI_API_KEY="sk-..."
+   ```
+
+3. Build the vector store for your chapter links:
+
+   ```bash
+   python build_vector_store.py
+   ```
+
+   Adjust the `links` list in the script as needed.
+
+4. Launch the app:
+
+   ```bash
+   streamlit run app.py
+   ```
+
+You can then ask questions against the downloaded chapters using the
+`gpt-5-nano` model.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,34 @@
+"""Streamlit interface for asking questions about scraped chapters."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import streamlit as st
+from langchain.chains import RetrievalQA
+from langchain.embeddings.openai import OpenAIEmbeddings
+from langchain.llms import OpenAI
+from langchain.vectorstores import FAISS
+
+INDEX_PATH = Path("vector_store")
+
+@st.cache_resource
+def load_store() -> FAISS:
+    embeddings = OpenAIEmbeddings()
+    return FAISS.load_local(str(INDEX_PATH), embeddings)
+
+
+def main() -> None:
+    st.title("MangaGPT Q&A")
+    question = st.text_input("Ask a question about the manga")
+    if st.button("Answer") and question:
+        store = load_store()
+        qa_chain = RetrievalQA.from_chain_type(
+            llm=OpenAI(model_name="gpt-5-nano"),
+            retriever=store.as_retriever(),
+        )
+        answer = qa_chain.run(question)
+        st.write(answer)
+
+
+if __name__ == "__main__":
+    main()

--- a/build_vector_store.py
+++ b/build_vector_store.py
@@ -1,0 +1,53 @@
+"""Utility to scrape chapter pages and build a FAISS vector store."""
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+from typing import Iterable
+
+import requests
+from bs4 import BeautifulSoup
+from langchain.embeddings.openai import OpenAIEmbeddings
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.vectorstores import FAISS
+
+
+DEFAULT_INDEX_PATH = Path("vector_store")
+
+
+def fetch_text(url: str) -> str:
+    """Download a web page and return plain text.
+
+    Parameters
+    ----------
+    url: str
+        Web page URL.
+    """
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+    return soup.get_text("\n", strip=True)
+
+
+def build_vector_store(urls: Iterable[str], index_path: Path = DEFAULT_INDEX_PATH) -> None:
+    """Fetch all URLs and persist a FAISS vector store locally.
+
+    The function splits the downloaded text into overlapping chunks and
+    computes OpenAI embeddings for each chunk before saving the index to
+    ``index_path``.
+    """
+    texts = [fetch_text(u) for u in urls]
+    splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+    docs = splitter.create_documents(texts)
+    embeddings = OpenAIEmbeddings()
+    store = FAISS.from_documents(docs, embeddings)
+    store.save_local(str(index_path))
+
+
+if __name__ == "__main__":
+    # Example usage for manual runs
+    links = [
+        "https://onepiece.fandom.com/wiki/Chapter_1140",
+    ]
+    build_vector_store(links)
+    print(f"Vector store written to {DEFAULT_INDEX_PATH}/")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+openai
+langchain
+streamlit
+beautifulsoup4
+faiss-cpu


### PR DESCRIPTION
## Summary
- scrape chapter pages and create FAISS vector store with OpenAI embeddings
- streamlit UI to query chapters using gpt-5-nano model
- document setup and dependencies

## Testing
- `python -m py_compile build_vector_store.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68acbff4dce0832fa6a771e4bfd88270