### PR TITLE
feat: update vector store builder for new chapters

### DIFF
--- a/build_vector_store.py
+++ b/build_vector_store.py
@@ -1,9 +1,8 @@
 """Utility to scrape chapter pages and build a FAISS vector store."""
 from __future__ import annotations
 
-import pickle
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, List, Set
 
 import requests
 from bs4 import BeautifulSoup
@@ -34,20 +33,77 @@ def build_vector_store(urls: Iterable[str], index_path: Path = DEFAULT_INDEX_PAT
 
     The function splits the downloaded text into overlapping chunks and
     computes OpenAI embeddings for each chunk before saving the index to
-    ``index_path``.
+    ``index_path``. When ``index_path`` already exists, only new chapters
+    (based on their source URL) are embedded and appended to the store.
     """
-    texts = [fetch_text(u) for u in urls]
-    splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
-    docs = splitter.create_documents(texts)
+
     embeddings = OpenAIEmbeddings()
-    store = FAISS.from_documents(docs, embeddings)
+
+    # Load existing index if present to avoid re-processing chapters
+    if index_path.exists():
+        store = FAISS.load_local(str(index_path), embeddings, allow_dangerous_deserialization=True)
+        existing: Set[str] = {doc.metadata.get("source") for doc in store.docstore._dict.values()}
+    else:
+        store = None
+        existing = set()
+
+    # Fetch and prepare documents for URLs not yet indexed
+    new_texts: List[str] = []
+    new_meta: List[dict] = []
+    for url in urls:
+        if url in existing:
+            continue
+        new_texts.append(fetch_text(url))
+        new_meta.append({"source": url})
+
+    if not new_texts:
+        return
+
+    splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+    docs = splitter.create_documents(new_texts, metadatas=new_meta)
+
+    if store is None:
+        store = FAISS.from_documents(docs, embeddings)
+    else:
+        store.add_documents(docs)
+
     store.save_local(str(index_path))
 
 
+def fetch_chapter_links(start: int = 1) -> List[str]:
+    """Return links for all chapters starting from ``start``.
+
+    The function sequentially probes chapter pages until a 404 response is
+    encountered, yielding the set of available chapter URLs.
+    """
+    base = "https://onepiece.fandom.com/wiki/Chapter_{}"
+    links: List[str] = []
+    num = start
+    while True:
+        url = base.format(num)
+        resp = requests.head(url, timeout=30)
+        if resp.status_code == 200:
+            links.append(url)
+            num += 1
+        else:
+            break
+    return links
+
+
 if __name__ == "__main__":
-    # Example usage for manual runs
-    links = [
-        "https://onepiece.fandom.com/wiki/Chapter_1140",
-    ]
+    # Determine the next chapter to fetch based on the existing index
+    start_chapter = 1
+    if DEFAULT_INDEX_PATH.exists():
+        embeddings = OpenAIEmbeddings()
+        store = FAISS.load_local(
+            str(DEFAULT_INDEX_PATH),
+            embeddings,
+            allow_dangerous_deserialization=True,
+        )
+        sources = [doc.metadata.get("source") for doc in store.docstore._dict.values()]
+        chapters = [int(s.rsplit("_", 1)[-1]) for s in sources if s and s.rsplit("_", 1)[-1].isdigit()]
+        start_chapter = max(chapters, default=0) + 1
+
+    links = fetch_chapter_links(start_chapter)
     build_vector_store(links)
     print(f"Vector store written to {DEFAULT_INDEX_PATH}/")


### PR DESCRIPTION
## Summary
- update vector store builder to skip already indexed chapters
- add helper to fetch new chapter links sequentially
- update manual run to automatically gather and index new chapters

## Testing
- `python -m py_compile build_vector_store.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acc1ca3298832fb9b7e83a395fac44